### PR TITLE
fix: Update tailwind.config.ts for Tailwind CSS v4 compatibility

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,12 +1,11 @@
 import { type Config } from "tailwindcss";
-import { fontFamily } from "tailwindcss/defaultTheme";
 
 export default {
   content: ["./src/**/*.tsx"],
   theme: {
     extend: {
       fontFamily: {
-        sans: ["var(--font-geist-sans)", ...fontFamily.sans],
+        sans: ["var(--font-geist-sans)", "ui-sans-serif", "system-ui", "sans-serif"],
       },
     },
   },


### PR DESCRIPTION
## Summary
- Remove `fontFamily` import from `tailwindcss/defaultTheme` as it no longer exists in Tailwind CSS v4
- Use explicit font stack instead of spreading from default theme

## Test plan
- [x] pnpm typecheck passes
- [x] pnpm lint passes
- [x] pnpm build succeeds
- [x] App runs locally without errors
- [ ] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)