### PR TITLE
chore: Switch to Blacksmith CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
Switches GitHub Actions runner from GitHub-hosted to Blacksmith for faster CI builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration infrastructure to optimize build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->